### PR TITLE
tests, filler records, line endings, addenda, encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/blib
+/pm_to_blib
+/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /MYMETA.json
 /MYMETA.yml
 /Makefile
+/Makefile.old
 /blib
 /pm_to_blib
 /*.tar.gz

--- a/lib/ACH/Builder.pm
+++ b/lib/ACH/Builder.pm
@@ -52,6 +52,9 @@ ACH::Builder - Tools for building ACH (Automated Clearing House) files
   # build file control record
   $ach->make_file_control_record;
 
+  # add 9's filler records as needed
+  $ach->make_filler_records;
+
   print $ach->to_string;
 
 =head1 DESCRIPTION
@@ -502,6 +505,24 @@ sub make_file_control_record {
         fixedlength( $self->format_rules(), $data, \@def )
     );
 }
+
+=pod
+
+=head2 make_filler_records( )
+
+Adds filler records (all 9's) as needed to fill out last block, so that the
+total number of records is a multiple of 10.
+
+=cut
+
+sub make_filler_records
+{
+  my $self = shift;
+  while (@{$self->ach_data} % 10 != 0) {
+    push @{$self->ach_data}, '9' x $self->{__RECORD_SIZE__};
+  }
+}
+
 
 =pod
 

--- a/lib/ACH/Builder.pm
+++ b/lib/ACH/Builder.pm
@@ -591,15 +591,16 @@ sub fixedlength {
 
 =pod
 
-=head2 to_string( )
+=head2 to_string([$line_term])
 
-Returns the built ACH file.
+Returns the built ACH file. $line_term is added to each line (default "\n")
 
 =cut
 
 sub to_string {
-    my $self = shift;
-    return( join( "\n", @{ $self->{__ACH_DATA__} } ) );
+    my ($self, $line_term) = @_;
+    $line_term = "\n" unless defined($line_term);
+    join('', map "$_$line_term", @{ $self->ach_data } );
 }
 
 =pod

--- a/lib/ACH/Builder.pm
+++ b/lib/ACH/Builder.pm
@@ -518,7 +518,7 @@ total number of records is a multiple of 10.
 sub make_filler_records
 {
   my $self = shift;
-  while (@{$self->ach_data} % 10 != 0) {
+  while (@{$self->ach_data} % $self->{__BLOCKING_FACTOR__} != 0) {
     push @{$self->ach_data}, '9' x $self->{__RECORD_SIZE__};
   }
 }

--- a/lib/ACH/Builder.pm
+++ b/lib/ACH/Builder.pm
@@ -6,6 +6,7 @@ no warnings 'uninitialized';
 
 use POSIX qw( ceil strftime );
 use Carp qw( carp croak );
+use Encode qw( encode );
 
 our $VERSION = '0.21';
 
@@ -634,6 +635,7 @@ sub format_rules {
 }
 
 # For internal use only. Formats a record according to format_rules.
+# non-ASCII characters are replaced with a substitution characer ("?").
 sub fixedlength {
     my( $format, $data, $order ) = @_;
 
@@ -647,7 +649,7 @@ sub fixedlength {
 
         $data->{$field} ||= "";
 
-        $fmt_string .= sprintf $format->{$field}, $data->{$field};
+        $fmt_string .= sprintf $format->{$field}, encode('ascii', $data->{$field}, Encode::FB_DEFAULT);
     }
 
     return $fmt_string;
@@ -1027,6 +1029,12 @@ ACH file structure:
 
 Only certain types of ACH transactions are supported (see the detail
 record format above).
+
+=head1 ENCODING
+
+The ACH file format only supports ASCII characters. All data is converted to
+ASCII using Encode::encode(). Any non-ASCII characters in the input are
+replaced with a substitution character ("?").
 
 =head1 AUTHOR
 

--- a/lib/ACH/Builder.pm
+++ b/lib/ACH/Builder.pm
@@ -2,6 +2,7 @@ package ACH::Builder;
 
 use strict;
 use warnings;
+no warnings 'uninitialized';
 
 use POSIX qw( ceil strftime );
 use Carp qw( carp croak );

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use Test::More;
+BEGIN { use_ok('ACH::Builder') };
+
+done_testing(1);

--- a/t/01-format.t
+++ b/t/01-format.t
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+
+use Test::More;
+use ACH::Builder;
+
+my $sample_config = {
+  company_id        => '11-111111',
+  company_name      => 'MY COMPANY',
+  entry_description => 'TV-TELCOM',
+  destination       => '123123123',
+  destination_name  => 'COMMERCE BANK',
+  origination       => '12312311',
+  origination_name  => 'MYCOMPANY',
+  company_note      => 'BILL',
+  effective_date    => '130903',
+  creation_date     => '130903',
+  creation_time     => '1234',
+};
+
+my $sample_lines = [
+  '101 123123123  123123111309031234A094101COMMERCE BANK          MYCOMPANY                      ',
+  '5200MY COMPANY      BILL                11-111111 WEBTV-TELCOM 130903130903   1123123110000001',
+  '627010010101103030030        00000025011234-0123456   JOHN SMITH              0123123110000002',
+  '632010010401440030030        0000002501verylongaccountALICE VERYLONGNAMEGETS  0123123110000003',
+  '8200000002000200205000000000250100000000250111-111111                          123123110000001',
+  '9000001000001000000020002002050000000002501000000002501                                       ',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+];
+
+my $ach;
+
+# create builder
+$ach = ACH::Builder->new($sample_config);
+is(scalar @{$ach->ach_data}, 0, 'new builder');
+
+# add file header record
+$ach->make_file_header_record;
+is(scalar @{$ach->ach_data}, 1, 'record count after file header');
+is($ach->ach_data->[0], $sample_lines->[0], 'file header record format');
+
+# add batch for sample records
+$ach->set_entry_class_code('WEB');
+$ach->make_batch([$ach->sample_detail_records]);
+is(scalar @{$ach->ach_data}, 5, 'record count after batch');
+is($ach->ach_data->[1], $sample_lines->[1], 'batch header record format');
+is($ach->ach_data->[2], $sample_lines->[2], 'entry detail record format');
+is($ach->ach_data->[3], $sample_lines->[3], 'entry detail record format');
+is($ach->ach_data->[4], $sample_lines->[4], 'batch control record format');
+
+# add file control record
+$ach->make_file_control_record;
+is(scalar @{$ach->ach_data}, 6, 'record count after file control');
+is($ach->ach_data->[5], $sample_lines->[5], 'file control record format');
+
+# add 9's filler records
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 10, 'record count after filler');
+is($ach->ach_data->[$_], $sample_lines->[$_], 'filler record format') for 6..9;
+
+done_testing(15);

--- a/t/02-to_string.t
+++ b/t/02-to_string.t
@@ -1,22 +1,8 @@
-# Before `make install' is performed this script should be runnable with
-# `make test'. After `make install' it should work as `perl ACH-Builder.t'
-
-#########################
-
 use strict;
 use warnings;
 
-# change 'tests => 1' to 'tests => last_test_to_print';
-
 use Test::More;
-BEGIN { use_ok('ACH::Builder') };
-
-#########################
-
-# Insert your test code below, the Test::More module is use()ed here so read
-# its man page ( perldoc Test::More ) for help writing this test script.
-
-isa_ok(ACH::Builder->new, 'ACH::Builder', 'empty constructor');
+use ACH::Builder;
 
 my $sample_config = {
   company_id        => '11-111111',
@@ -47,47 +33,16 @@ my $sample_lines = [
 
 my $ach;
 
-# create builder
 $ach = ACH::Builder->new($sample_config);
-is(scalar @{$ach->ach_data}, 0, 'new builder');
-
-# add file header record
 $ach->make_file_header_record;
-is(scalar @{$ach->ach_data}, 1, 'record count after file header');
-is($ach->ach_data->[0], $sample_lines->[0], 'file header record format');
-
-# add batch for sample records
 $ach->set_entry_class_code('WEB');
 $ach->make_batch([$ach->sample_detail_records]);
-is(scalar @{$ach->ach_data}, 5, 'record count after batch');
-is($ach->ach_data->[1], $sample_lines->[1], 'batch header record format');
-is($ach->ach_data->[2], $sample_lines->[2], 'entry detail record format');
-is($ach->ach_data->[3], $sample_lines->[3], 'entry detail record format');
-is($ach->ach_data->[4], $sample_lines->[4], 'batch control record format');
-
-# add file control record
 $ach->make_file_control_record;
-is(scalar @{$ach->ach_data}, 6, 'record count after file control');
-is($ach->ach_data->[5], $sample_lines->[5], 'file control record format');
-
-# add 9's filler records
 $ach->make_filler_records;
-is(scalar @{$ach->ach_data}, 10, 'record count after filler');
-is($ach->ach_data->[$_], $sample_lines->[$_], 'filler record format') for 6..9;
-
-$ach->make_filler_records;
-is(scalar @{$ach->ach_data}, 10, 'record count after redundant filler');
 
 # test combining lines
 is(join('', map "$_\n", @{$sample_lines}), $ach->to_string, 'default terminator');
 is(join('', map "${_}X", @{$sample_lines}), $ach->to_string('X'), 'alternate terminator');
 is(join('', @{$sample_lines}), $ach->to_string(''), 'no terminator');
 
-# test alternate blocking factor
-$ach = ACH::Builder->new($sample_config);
-$ach->{__BLOCKING_FACTOR__} = 3;
-$ach->make_file_header_record;
-$ach->make_filler_records;
-is(scalar @{$ach->ach_data}, 3, 'record count with blocking factor 3');
-
-done_testing(22);
+done_testing(3);

--- a/t/03-blocking_factor.t
+++ b/t/03-blocking_factor.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+use ACH::Builder;
+
+my $sample_config = {
+  company_id        => '11-111111',
+  company_name      => 'MY COMPANY',
+  entry_description => 'TV-TELCOM',
+  destination       => '123123123',
+  destination_name  => 'COMMERCE BANK',
+  origination       => '12312311',
+  origination_name  => 'MYCOMPANY',
+  company_note      => 'BILL',
+  effective_date    => '130903',
+  creation_date     => '130903',
+  creation_time     => '1234',
+};
+
+my $ach;
+
+# test alternate blocking factor
+$ach = ACH::Builder->new($sample_config);
+$ach->{__BLOCKING_FACTOR__} = 3;
+$ach->make_file_header_record;
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 3, 'record count with blocking factor 3');
+
+done_testing(1);

--- a/t/04-addenda.t
+++ b/t/04-addenda.t
@@ -1,0 +1,63 @@
+use strict;
+use warnings;
+
+use Test::More;
+use ACH::Builder;
+
+my $sample_config = {
+  company_id        => '11-111111',
+  company_name      => 'MY COMPANY',
+  entry_description => 'TV-TELCOM',
+  destination       => '123123123',
+  destination_name  => 'COMMERCE BANK',
+  origination       => '12312311',
+  origination_name  => 'MYCOMPANY',
+  company_note      => 'BILL',
+  effective_date    => '130903',
+  creation_date     => '130903',
+  creation_time     => '1234',
+  allow_unbalanced_file => 1,
+};
+
+my $sample_entries = [
+  {
+    customer_name       => 'JOHN SMITH',
+    customer_acct       => '1234-0123456',
+    amount              => '2501',
+    routing_number      => '010010101',
+    bank_account        => '103030030',
+    transaction_code    => '27',
+    addenda             => [
+      {
+        addendum_code => '05',
+        addendum_info => 'Addendum Info 1',
+      },
+    ],
+  },
+];
+
+my $sample_lines = [
+  '101 123123123  123123111309031234A094101COMMERCE BANK          MYCOMPANY                      ',
+  '5200MY COMPANY      BILL                11-111111 WEBTV-TELCOM 130903130903   1123123110000001',
+  '627010010101103030030        00000025011234-0123456   JOHN SMITH              1123123110000002',
+  '705Addendum Info 1                                                                 00010000002',
+  '8200000002000100101000000000250100000000000011-111111                          123123110000001',
+  '9000001000001000000020001001010000000002501000000000000                                       ',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+];
+
+my $ach;
+
+$ach = ACH::Builder->new($sample_config);
+$ach->make_file_header_record;
+$ach->set_entry_class_code('WEB');
+$ach->make_batch($sample_entries);
+$ach->make_file_control_record;
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 10, 'record count after filler');
+is($ach->ach_data->[$_], $sample_lines->[$_], 'filler record format') for 0..9;
+
+done_testing(11);

--- a/t/05-encoding.t
+++ b/t/05-encoding.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More;
+use ACH::Builder;
+
+my $sample_config = {
+  company_id        => '11-111111',
+  company_name      => 'MY COMPANY',
+  destination       => '123123123',
+  destination_name  => 'COMMERCE BANK',
+  origination       => '12312311',
+  origination_name  => "Se\x{00f1}or Frog",
+  company_note      => 'BILL',
+  creation_date     => '130903',
+  creation_time     => '1234',
+};
+
+my $ach = ACH::Builder->new($sample_config);
+
+$ach->make_file_header_record;
+is('101 123123123  123123111309031234A094101COMMERCE BANK          Se?or Frog                     ' , $ach->ach_data->[0], 'replace non-ascii chars');
+
+done_testing();

--- a/t/05-encoding.t
+++ b/t/05-encoding.t
@@ -21,4 +21,4 @@ my $ach = ACH::Builder->new($sample_config);
 $ach->make_file_header_record;
 is('101 123123123  123123111309031234A094101COMMERCE BANK          Se?or Frog                     ' , $ach->ach_data->[0], 'replace non-ascii chars');
 
-done_testing();
+done_testing(1);

--- a/t/ACH-Builder.t
+++ b/t/ACH-Builder.t
@@ -67,6 +67,8 @@ is(scalar @{$ach->ach_data}, 6, 'record count after file control');
 is($ach->ach_data->[5], $sample_lines->[5], 'file control record format');
 
 # test combining lines
-is(join("\n", @{$sample_lines}), $ach->to_string, 'to_string');
+is(join('', map "$_\n", @{$sample_lines}), $ach->to_string, 'default terminator');
+is(join('', map "${_}X", @{$sample_lines}), $ach->to_string('X'), 'alternate terminator');
+is(join('', @{$sample_lines}), $ach->to_string(''), 'no terminator');
 
-done_testing(13);
+done_testing(15);

--- a/t/ACH-Builder.t
+++ b/t/ACH-Builder.t
@@ -39,6 +39,10 @@ my $sample_lines = [
   '632010010401440030030        0000002501verylongaccountALICE VERYLONGNAMEGETS  0123123110000003',
   '8200000002000200205000000000250100000000250111-111111                          123123110000001',
   '9000001000001000000020002002050000000002501000000002501                                       ',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
+  '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999',
 ];
 
 my $ach;
@@ -66,9 +70,17 @@ $ach->make_file_control_record;
 is(scalar @{$ach->ach_data}, 6, 'record count after file control');
 is($ach->ach_data->[5], $sample_lines->[5], 'file control record format');
 
+# add 9's filler records
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 10, 'record count after filler');
+is($ach->ach_data->[$_], $sample_lines->[$_], 'filler record format') for 6..9;
+
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 10, 'record count after redundant filler');
+
 # test combining lines
 is(join('', map "$_\n", @{$sample_lines}), $ach->to_string, 'default terminator');
 is(join('', map "${_}X", @{$sample_lines}), $ach->to_string('X'), 'alternate terminator');
 is(join('', @{$sample_lines}), $ach->to_string(''), 'no terminator');
 
-done_testing(15);
+done_testing(21);

--- a/t/ACH-Builder.t
+++ b/t/ACH-Builder.t
@@ -3,9 +3,12 @@
 
 #########################
 
+use strict;
+use warnings;
+
 # change 'tests => 1' to 'tests => last_test_to_print';
 
-use Test::More tests => 1;
+use Test::More;
 BEGIN { use_ok('ACH::Builder') };
 
 #########################
@@ -13,3 +16,57 @@ BEGIN { use_ok('ACH::Builder') };
 # Insert your test code below, the Test::More module is use()ed here so read
 # its man page ( perldoc Test::More ) for help writing this test script.
 
+isa_ok(ACH::Builder->new, 'ACH::Builder', 'empty constructor');
+
+my $sample_config = {
+  company_id        => '11-111111',
+  company_name      => 'MY COMPANY',
+  entry_description => 'TV-TELCOM',
+  destination       => '123123123',
+  destination_name  => 'COMMERCE BANK',
+  origination       => '12312311',
+  origination_name  => 'MYCOMPANY',
+  company_note      => 'BILL',
+  effective_date    => '130903',
+  creation_date     => '130903',
+  creation_time     => '1234',
+};
+
+my $sample_lines = [
+  '101 123123123  123123111309031234A094101COMMERCE BANK          MYCOMPANY                      ',
+  '5200MY COMPANY      BILL                11-111111 WEBTV-TELCOM 130903130903   1123123110000001',
+  '627010010101103030030        00000025011234-0123456   JOHN SMITH              0123123110000002',
+  '632010010401440030030        0000002501verylongaccountALICE VERYLONGNAMEGETS  0123123110000003',
+  '8200000002000200205000000000250100000000250111-111111                          123123110000001',
+  '9000001000001000000020002002050000000002501000000002501                                       ',
+];
+
+my $ach;
+
+# create builder
+$ach = ACH::Builder->new($sample_config);
+is(scalar @{$ach->ach_data}, 0, 'new builder');
+
+# add file header record
+$ach->make_file_header_record;
+is(scalar @{$ach->ach_data}, 1, 'record count after file header');
+is($ach->ach_data->[0], $sample_lines->[0], 'file header record format');
+
+# add batch for sample records
+$ach->set_entry_class_code('WEB');
+$ach->make_batch([$ach->sample_detail_records]);
+is(scalar @{$ach->ach_data}, 5, 'record count after batch');
+is($ach->ach_data->[1], $sample_lines->[1], 'batch header record format');
+is($ach->ach_data->[2], $sample_lines->[2], 'entry detail record format');
+is($ach->ach_data->[3], $sample_lines->[3], 'entry detail record format');
+is($ach->ach_data->[4], $sample_lines->[4], 'batch control record format');
+
+# add file control record
+$ach->make_file_control_record;
+is(scalar @{$ach->ach_data}, 6, 'record count after file control');
+is($ach->ach_data->[5], $sample_lines->[5], 'file control record format');
+
+# test combining lines
+is(join("\n", @{$sample_lines}), $ach->to_string, 'to_string');
+
+done_testing(13);

--- a/t/ACH-Builder.t
+++ b/t/ACH-Builder.t
@@ -83,4 +83,11 @@ is(join('', map "$_\n", @{$sample_lines}), $ach->to_string, 'default terminator'
 is(join('', map "${_}X", @{$sample_lines}), $ach->to_string('X'), 'alternate terminator');
 is(join('', @{$sample_lines}), $ach->to_string(''), 'no terminator');
 
-done_testing(21);
+# test alternate blocking factor
+$ach = ACH::Builder->new($sample_config);
+$ach->{__BLOCKING_FACTOR__} = 3;
+$ach->make_file_header_record;
+$ach->make_filler_records;
+is(scalar @{$ach->ach_data}, 3, 'record count with blocking factor 3');
+
+done_testing(22);


### PR DESCRIPTION
Hi,

Here are some enhancements if you would like them. Thanks for the module!

* Added test coverage
* Added ability to specify the line terminator for `to_string()`
* Added `make_filler_records()` to add 9's rows to fill last block
* Added basic support for creating addenda records
* Added conversion of all inputs to ASCII, replacing non-ASCII chars with substitution character

There are two backward-incompatible changes here, but I don't think they are significant enough to impact anyone:

* The line terminator (default "\n") is added to the last line by to_string(), where previously the last line did not have a terminator.
* The `addenda` value has been changed to `addenda_indicator`. `addenda` is now used to supply an optional arrayref of addenda entries within each detail entry.